### PR TITLE
[Fix]correct lazy allocation of syscall

### DIFF
--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -68,25 +68,6 @@ int
 argaddr(int n, uint64 *ip)
 {
   *ip = argraw(n);
-  struct proc* p = myproc();
-
-  // 处理向系统调用传入lazy allocation地址的情况
-  if(walkaddr(p->pagetable, *ip) == 0) {
-    if(PGROUNDUP(p->trapframe->sp) - 1 < *ip && *ip < p->sz) {
-      char* pa = kalloc();
-      if(pa == 0)
-        return -1;
-      memset(pa, 0, PGSIZE);
-
-      if(mappages(p->pagetable, PGROUNDDOWN(*ip), PGSIZE, (uint64)pa, PTE_R | PTE_W | PTE_X | PTE_U) != 0) {
-        kfree(pa);
-        return -1;
-      }
-    } else {
-      return -1;
-    }
-  }
-
   return 0;
 }
 


### PR DESCRIPTION
As mentioned in #1 , during syscall, pages could be lazy allocated, then such pages should be allocted with new physical pages.
In previous implementations, one just alloc a single page to virtual address fetched in `argaddr`, which could go wrong when  syscall need to do read/write on more than one pages.
In this version, one just need to check whether the missing page is a lazy-allocated page, and if so, alloc a physical page. Because reading memory from a given user space addr will only happened in `copyin` (and `copyinstr`) and `copyout`, we just need to change the mentioned function.
Implementation has passed test(ignore the missing `time.txt`):
<img width="307" alt="image" src="https://user-images.githubusercontent.com/50511903/187376738-43cc6061-4fcc-4aed-aad5-2c74e9c1d1b2.png">
